### PR TITLE
faiss-sys: Link to 'omp' on macOS instead of 'gomp'

### DIFF
--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -460,6 +460,8 @@ pub struct IndexImpl {
     inner: *mut FaissIndex,
 }
 
+impl_concurrent_index!(IndexImpl);
+
 unsafe impl Send for IndexImpl {}
 unsafe impl Sync for IndexImpl {}
 


### PR DESCRIPTION
Link to libomp on non-Linux platforms instead of libgomp.

On macOS, add homebrew's default libomp install directory to the
linker search path.Link to libomp on non-Linux platforms instead of libgomp.

On macOS, add homebrew's default libomp install directory to the
linker search path.